### PR TITLE
Support new launcher name

### DIFF
--- a/elite_dangerous_rich_presence/journal_reader.py
+++ b/elite_dangerous_rich_presence/journal_reader.py
@@ -22,6 +22,7 @@ def launcher_active():
     return bool(
         win32gui.FindWindow(None, "Elite Dangerous Launcher")
         or win32gui.FindWindow(None, "elite-launcher")
+        or win32gui.FindWindow(None, "elite launcher")
     )
 
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/96f45e57-5441-4925-8de0-c20104110ada)
Dunno when they changed it. I just appended it to the list of checked names in the `journal_reader.py`